### PR TITLE
RDS Parameter Group - removing false commentary

### DIFF
--- a/lib/fog/aws/requests/rds/create_db_parameter_group.rb
+++ b/lib/fog/aws/requests/rds/create_db_parameter_group.rb
@@ -8,7 +8,7 @@ module Fog
         # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/API_CreateDBParameterGroup.html
         # ==== Parameters
         # * DBParameterGroupName <~String> - name of the parameter group
-        # * DBParameterGroupFamily <~String> - The DB parameter group family name. Current valid values: MySQL5.1 | MySQL5.5
+        # * DBParameterGroupFamily <~String> - The DB parameter group family name.
         # * Description <~String> - The description for the DB Parameter Grou
         #
         # ==== Returns


### PR DESCRIPTION
At EngineYard, we've been creating different types of parameter group families other than the mentioned in this comment, so I know it's wrong.

Plus, I checked AWS documentation and they say to run this AWS CLI command to determine the valid values:
`aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily" --region us-east-1`

And it returns to me many more values than the ones in the commentary. Removing the duplicates I got: 
```
["aurora-mysql5.7",
 "aurora-postgresql10",
 "aurora-postgresql9.6",
 "aurora5.6",
 "docdb3.6",
 "mariadb10.0",
 "mariadb10.1",
 "mariadb10.2",
 "mariadb10.3",
 "mysql5.5",
 "mysql5.6",
 "mysql5.7",
 "mysql8.0",
 "neptune1",
 "oracle-ee-11.2",
 "oracle-ee-12.1",
 "oracle-ee-12.2",
 "oracle-ee-18",
 "oracle-se-11.2",
 "oracle-se1-11.2",
 "oracle-se2-12.1",
 "oracle-se2-12.2",
 "oracle-se2-18",
 "postgres10",
 "postgres11",
 "postgres9.3",
 "postgres9.4",
 "postgres9.5",
 "postgres9.6",
 "sqlserver-ee-11.0",
 "sqlserver-ee-12.0",
 "sqlserver-ee-13.0",
 "sqlserver-ee-14.0",
 "sqlserver-ex-11.0",
 "sqlserver-ex-12.0",
 "sqlserver-ex-13.0",
 "sqlserver-ex-14.0",
 "sqlserver-se-11.0",
 "sqlserver-se-12.0",
 "sqlserver-se-13.0",
 "sqlserver-se-14.0",
 "sqlserver-web-11.0",
 "sqlserver-web-12.0",
 "sqlserver-web-13.0",
 "sqlserver-web-14.0"]
```